### PR TITLE
fix: Reflect line breaks in word meaning display

### DIFF
--- a/src/app/wordBooks/[id]/learn/LearnContent.tsx
+++ b/src/app/wordBooks/[id]/learn/LearnContent.tsx
@@ -26,6 +26,13 @@ export function LearnContent({ initialWords }: LearnContentProps) {
     setCurrentWordIndex((prevIndex) => prevIndex + 1);
   }, []);
 
+  const formattedMeaning = currentWordData?.meaning
+    ? currentWordData.meaning.split("\n").map((line) => ({
+        id: crypto.randomUUID(),
+        text: line,
+      }))
+    : [];
+
   const handleShowAnswer = () => {
     setShowMeaning(true);
   };
@@ -89,7 +96,13 @@ export function LearnContent({ initialWords }: LearnContentProps) {
           <CardTitle>{currentWordData.term}</CardTitle>
         </CardHeader>
         <CardContent>
-          {showMeaning && <p className="mb-4">{currentWordData.meaning}</p>}
+          {showMeaning && (
+            <div className="mb-4">
+              {formattedMeaning.map((item) => (
+                <p key={item.id}>{item.text}</p>
+              ))}
+            </div>
+          )}
           {!showMeaning && (
             <div>
               <Button className="w-full" onClick={handleShowAnswer}>

--- a/src/app/wordBooks/[id]/learn/LearnContent.tsx
+++ b/src/app/wordBooks/[id]/learn/LearnContent.tsx
@@ -26,13 +26,6 @@ export function LearnContent({ initialWords }: LearnContentProps) {
     setCurrentWordIndex((prevIndex) => prevIndex + 1);
   }, []);
 
-  const formattedMeaning = currentWordData?.meaning
-    ? currentWordData.meaning.split("\n").map((line) => ({
-        id: crypto.randomUUID(),
-        text: line,
-      }))
-    : [];
-
   const handleShowAnswer = () => {
     setShowMeaning(true);
   };
@@ -97,11 +90,9 @@ export function LearnContent({ initialWords }: LearnContentProps) {
         </CardHeader>
         <CardContent>
           {showMeaning && (
-            <div className="mb-4">
-              {formattedMeaning.map((item) => (
-                <p key={item.id}>{item.text}</p>
-              ))}
-            </div>
+            <p className="mb-4 whitespace-pre-wrap">
+              {currentWordData.meaning}
+            </p>
           )}
           {!showMeaning && (
             <div>


### PR DESCRIPTION
- `formatTextWithLineBreaks` ユーティリティ関数を削除しました。
- `LearnContent.tsx` で、改行コードで分割し、`<p>` タグにマッピングすることで、整形された単語の意味を表示するようにしました。
- マッピングされた要素のキーとして `crypto.randomUUID()` を使用し、リンティングエラーを回避しました。

Closes #23