### PR TITLE
feat: Display learning stats during word learning

### DIFF
--- a/src/app/wordBooks/[id]/learn/LearnContent.tsx
+++ b/src/app/wordBooks/[id]/learn/LearnContent.tsx
@@ -16,6 +16,10 @@ export function LearnContent({ initialWords }: LearnContentProps) {
   const [error, setError] = useState<string | null>(null);
   const [isSendIncorrect, setIsSendIncorrect] = useState(false);
 
+  const [correctCount, setCorrectCount] = useState(0);
+  const [incorrectCount, setIncorrectCount] = useState(0);
+  const [learnedWordsCount, setLearnedWordsCount] = useState(0);
+
   const currentWordData =
     initialWords.length > 0 && currentWordIndex < initialWords.length
       ? initialWords[currentWordIndex]
@@ -35,7 +39,11 @@ export function LearnContent({ initialWords }: LearnContentProps) {
 
     if (result === "incorrect") {
       setIsSendIncorrect(true);
+      setIncorrectCount((prev) => prev + 1);
+    } else {
+      setCorrectCount((prev) => prev + 1);
     }
+    setLearnedWordsCount((prev) => prev + 1);
 
     try {
       const res = await client.learning.record.$post({
@@ -87,6 +95,11 @@ export function LearnContent({ initialWords }: LearnContentProps) {
       <Card className="w-full">
         <CardHeader>
           <CardTitle>{currentWordData.term}</CardTitle>
+          <div className="text-sm text-muted-foreground">
+            <p>学習単語数: {learnedWordsCount}</p>
+            <p>正解数: {correctCount}</p>
+            <p>不正解数: {incorrectCount}</p>
+          </div>
         </CardHeader>
         <CardContent>
           {showMeaning && <p className="mb-4">{currentWordData.meaning}</p>}

--- a/src/app/wordBooks/[id]/learn/LearnContent.tsx
+++ b/src/app/wordBooks/[id]/learn/LearnContent.tsx
@@ -90,53 +90,73 @@ export function LearnContent({ initialWords }: LearnContentProps) {
   }
 
   return (
-    <div className="container mx-auto flex justify-center items-center flex-1 p-4">
-      <Card className="w-full">
+    <div className="container mx-auto flex flex-1 p-4 flex-col gap-4">
+      <Card>
         <CardHeader>
-          <CardTitle>{currentWordData.term}</CardTitle>
-          <div className="flex justify-between text-sm text-muted-foreground">
-            <span>正解数: {learningStats.correctCount}</span>
-            <span>不正解数: {learningStats.incorrectCount}</span>
-            <span>
-              学習済み単語数:{" "}
-              {learningStats.correctCount + learningStats.incorrectCount}
-            </span>
-          </div>
+          <CardTitle>学習状況</CardTitle>
         </CardHeader>
         <CardContent>
-          {showMeaning && (
-            <p className="mb-4 whitespace-pre-wrap">
-              {currentWordData.meaning}
-            </p>
-          )}
-          {!showMeaning && (
-            <div>
-              <Button className="w-full" onClick={handleShowAnswer}>
-                答えを見る
-              </Button>
-            </div>
-          )}
-          {showMeaning && (
-            <div className="space-y-4">
-              <div className="flex justify-center gap-4">
-                <Button
-                  onClick={() => handleRecordResult("incorrect")}
-                  variant="destructive"
-                >
-                  不正解だった
-                </Button>
-                <Button onClick={() => handleRecordResult("correct")}>
-                  正解した
-                </Button>
-              </div>
-              <div className="flex justify-center gap-4">
-                <GoogleSearchLink term={currentWordData.term} />
-                <ChatGPTLink term={currentWordData.term} />
-              </div>
-            </div>
-          )}
+          <table className="text-sm text-muted-foreground">
+            <tbody>
+              <tr>
+                <td className="pr-4">正解数</td>
+                <td>{learningStats.correctCount}</td>
+              </tr>
+              <tr>
+                <td className="pr-4">不正解数</td>
+                <td>{learningStats.incorrectCount}</td>
+              </tr>
+              <tr>
+                <td className="pr-4">学習済み単語数</td>
+                <td>
+                  {learningStats.correctCount + learningStats.incorrectCount} /{" "}
+                  {initialWords.length}
+                </td>
+              </tr>
+            </tbody>
+          </table>
         </CardContent>
       </Card>
+      <div className="flex flex-1 justify-center items-center">
+        <Card className="w-full">
+          <CardHeader>
+            <CardTitle>{currentWordData.term}</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {showMeaning && (
+              <p className="mb-4 whitespace-pre-wrap">
+                {currentWordData.meaning}
+              </p>
+            )}
+            {!showMeaning && (
+              <div>
+                <Button className="w-full" onClick={handleShowAnswer}>
+                  答えを見る
+                </Button>
+              </div>
+            )}
+            {showMeaning && (
+              <div className="space-y-4">
+                <div className="flex justify-center gap-4">
+                  <Button
+                    onClick={() => handleRecordResult("incorrect")}
+                    variant="destructive"
+                  >
+                    不正解だった
+                  </Button>
+                  <Button onClick={() => handleRecordResult("correct")}>
+                    正解した
+                  </Button>
+                </div>
+                <div className="flex justify-center gap-4">
+                  <GoogleSearchLink term={currentWordData.term} />
+                  <ChatGPTLink term={currentWordData.term} />
+                </div>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
     </div>
   );
 }

--- a/src/app/wordBooks/[id]/learn/LearnContent.tsx
+++ b/src/app/wordBooks/[id]/learn/LearnContent.tsx
@@ -14,11 +14,13 @@ export function LearnContent({ initialWords }: LearnContentProps) {
   const [currentWordIndex, setCurrentWordIndex] = useState(0);
   const [showMeaning, setShowMeaning] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [isSendIncorrect, setIsSendIncorrect] = useState(false);
+  const [isSendIncorrect, _setIsSendIncorrect] = useState(false);
 
-  const [correctCount, setCorrectCount] = useState(0);
-  const [incorrectCount, setIncorrectCount] = useState(0);
-  const [learnedWordsCount, setLearnedWordsCount] = useState(0);
+  const [learningStats, setLearningStats] = useState({
+    correctCount: 0,
+    incorrectCount: 0,
+    learnedWordsCount: 0,
+  });
 
   const currentWordData =
     initialWords.length > 0 && currentWordIndex < initialWords.length
@@ -37,13 +39,14 @@ export function LearnContent({ initialWords }: LearnContentProps) {
   const handleRecordResult = async (result: "correct" | "incorrect") => {
     if (!currentWordData) return;
 
-    if (result === "incorrect") {
-      setIsSendIncorrect(true);
-      setIncorrectCount((prev) => prev + 1);
-    } else {
-      setCorrectCount((prev) => prev + 1);
-    }
-    setLearnedWordsCount((prev) => prev + 1);
+    setLearningStats((prev) => ({
+      ...prev,
+      correctCount:
+        result === "correct" ? prev.correctCount + 1 : prev.correctCount,
+      incorrectCount:
+        result === "incorrect" ? prev.incorrectCount + 1 : prev.incorrectCount,
+      learnedWordsCount: prev.learnedWordsCount + 1,
+    }));
 
     try {
       const res = await client.learning.record.$post({
@@ -96,9 +99,9 @@ export function LearnContent({ initialWords }: LearnContentProps) {
         <CardHeader>
           <CardTitle>{currentWordData.term}</CardTitle>
           <div className="text-sm text-muted-foreground">
-            <p>学習単語数: {learnedWordsCount}</p>
-            <p>正解数: {correctCount}</p>
-            <p>不正解数: {incorrectCount}</p>
+            <p>学習単語数: {learningStats.learnedWordsCount}</p>
+            <p>正解数: {learningStats.correctCount}</p>
+            <p>不正解数: {learningStats.incorrectCount}</p>
           </div>
         </CardHeader>
         <CardContent>

--- a/src/app/wordBooks/[id]/learn/LearnContent.tsx
+++ b/src/app/wordBooks/[id]/learn/LearnContent.tsx
@@ -14,12 +14,9 @@ export function LearnContent({ initialWords }: LearnContentProps) {
   const [currentWordIndex, setCurrentWordIndex] = useState(0);
   const [showMeaning, setShowMeaning] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [isSendIncorrect, _setIsSendIncorrect] = useState(false);
-
   const [learningStats, setLearningStats] = useState({
     correctCount: 0,
     incorrectCount: 0,
-    learnedWordsCount: 0,
   });
 
   const currentWordData =
@@ -45,7 +42,6 @@ export function LearnContent({ initialWords }: LearnContentProps) {
         result === "correct" ? prev.correctCount + 1 : prev.correctCount,
       incorrectCount:
         result === "incorrect" ? prev.incorrectCount + 1 : prev.incorrectCount,
-      learnedWordsCount: prev.learnedWordsCount + 1,
     }));
 
     try {
@@ -75,7 +71,7 @@ export function LearnContent({ initialWords }: LearnContentProps) {
   }
 
   if (!currentWordData) {
-    if (isSendIncorrect) {
+    if (learningStats.incorrectCount > 0) {
       return (
         <div className="container mx-auto flex flex-col gap-4 justify-center items-center flex-1 p-4">
           <p>リロードして間違えた単語を復習してください。</p>
@@ -98,10 +94,13 @@ export function LearnContent({ initialWords }: LearnContentProps) {
       <Card className="w-full">
         <CardHeader>
           <CardTitle>{currentWordData.term}</CardTitle>
-          <div className="text-sm text-muted-foreground">
-            <p>学習単語数: {learningStats.learnedWordsCount}</p>
-            <p>正解数: {learningStats.correctCount}</p>
-            <p>不正解数: {learningStats.incorrectCount}</p>
+          <div className="flex justify-between text-sm text-muted-foreground">
+            <span>正解数: {learningStats.correctCount}</span>
+            <span>不正解数: {learningStats.incorrectCount}</span>
+            <span>
+              学習済み単語数:{" "}
+              {learningStats.correctCount + learningStats.incorrectCount}
+            </span>
           </div>
         </CardHeader>
         <CardContent>

--- a/src/app/wordBooks/[id]/learn/LearnContent.tsx
+++ b/src/app/wordBooks/[id]/learn/LearnContent.tsx
@@ -37,14 +37,12 @@ export function LearnContent({ initialWords }: LearnContentProps) {
 
   const handleRecordResult = async (result: "correct" | "incorrect") => {
     if (!currentWordData) return;
-
-    setLearningStats((prev) => ({
-      ...prev,
-      correctCount:
-        result === "correct" ? prev.correctCount + 1 : prev.correctCount,
-      incorrectCount:
-        result === "incorrect" ? prev.incorrectCount + 1 : prev.incorrectCount,
-    }));
+    setLearningStats((prev) => {
+      if (result === "correct") {
+        return { ...prev, correctCount: prev.correctCount + 1 };
+      }
+      return { ...prev, incorrectCount: prev.incorrectCount + 1 };
+    });
 
     try {
       const res = await client.learning.record.$post({


### PR DESCRIPTION
- `correctCount`, `incorrectCount`, `learnedWordsCount` の状態変数を追加しました。
- `handleRecordResult` 関数内でこれらのカウントを更新するようにしました。
- `CardHeader` に学習統計情報 (`learnedWordsCount`, `correctCount`, `incorrectCount`) を表示するようにしました。

Closes #24