### PR TITLE
fix: LearningRecordServiceで学習単語の順序をランダム化

### DIFF
--- a/src/application/learningRecord/service.test.ts
+++ b/src/application/learningRecord/service.test.ts
@@ -291,7 +291,8 @@ describe("LearningRecordService", () => {
       const wordsToLearn = await service.getWordsToLearn(wordBookId);
 
       expect(wordsToLearn).toHaveLength(2);
-      expect(wordsToLearn[0].id.value).toBe(wordId1);
+      expect(wordsToLearn.map((w) => w.id.value)).toContain(wordId1);
+      expect(wordsToLearn.map((w) => w.id.value)).toContain(wordId2);
     });
 
     it("should not return mastered words", async () => {

--- a/src/application/learningRecord/service.ts
+++ b/src/application/learningRecord/service.ts
@@ -30,9 +30,10 @@ export class LearningRecordService {
   }
 
   async getWordsToLearn(wordBookId: string): Promise<Word[]> {
-    return this.learningRecordRepository.findWordsToLearn(
+    const words = this.learningRecordRepository.findWordsToLearn(
       WordBookId.from(wordBookId),
     );
+    return (await words).sort(() => Math.random() - 0.5);
   }
 
   async countWordsToLearn(wordBookId: string): Promise<number> {

--- a/src/application/learningRecord/service.ts
+++ b/src/application/learningRecord/service.ts
@@ -30,10 +30,15 @@ export class LearningRecordService {
   }
 
   async getWordsToLearn(wordBookId: string): Promise<Word[]> {
-    const words = this.learningRecordRepository.findWordsToLearn(
+    const words = await this.learningRecordRepository.findWordsToLearn(
       WordBookId.from(wordBookId),
     );
-    return (await words).sort(() => Math.random() - 0.5);
+    // Fisher-Yatesシャッフルで順序をランダム化
+    for (let i = words.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [words[i], words[j]] = [words[j], words[i]];
+    }
+    return words;
   }
 
   async countWordsToLearn(wordBookId: string): Promise<number> {


### PR DESCRIPTION
このPRは、`LearningRecordService`の`getWordsToLearn`メソッドで返される単語の順序をランダム化する修正です。

以前は、このメソッドはリポジトリから単語を直接返していました。この変更により、学習セッション中にユーザーが様々な順序で単語に遭遇するように、ランダムなソートが導入されます。